### PR TITLE
Enqueue and dequeue tasks to and from Postgres for processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ parts/
 sdist/
 var/
 wheels/
-pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
@@ -50,20 +49,11 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo
 *.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
 
 # Scrapy stuff:
 .scrapy
@@ -72,6 +62,7 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook
@@ -84,22 +75,11 @@ ipython_config.py
 # pyenv
 .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
+# poetry
+poetry.lock
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -127,3 +107,19 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# asdf
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -1,0 +1,181 @@
+# asyncpg-queue
+
+<h2 align="center">Postgres (asynchronous) queues</h1>
+
+<p align="center">
+<a href="https://github.com/n8sty/asyncpg-queue/blob/main/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+<a href="https://github.com/charliermarsh/ruff"><img alt="Linter: ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json">
+</p>
+
+Use Postgres to manage Python workloads asynchronously, powered by [asyncpg](https://github.com/MagicStack/asyncpg). asyncpg-queue is a simple library whose features include: 
+
+* Ability to run both synchronous and asynchronous Python callables
+* At-least-once execution of queued tasks
+* Scales with the number of database connections available
+* Dependency free apart from `asyncpg`
+* Uses Postgres notification channels to not thrash the database with unnecessary polling
+
+## Usage
+
+To get started using asyncpg-queue, initialize the Postgres objects that it relies on:
+
+```Python
+import asyncpg
+from asyncpg_queue import bootstrap
+
+db = asyncpg.connect("postgresql://postgres@127.0.0.1:5432/postgres")
+await bootstrap(db)
+```
+
+Now tasks can be enqueued for future processing. The `queue.put` method is naive and
+should, in most cases be used within a transaction like in the following contrived
+example:
+
+```Python
+from asyncpg_queue import queue
+
+db = asyncpg.connect("postgresql://postgres@127.0.0.1:5432/postgres")
+
+async with db.transaction():
+    await db.execute(
+        "INSERT INTO users (name, email) VALUES ($1, $2)",
+        "Someone Like a User",
+        "someone@example.com",
+    )
+    await queue.put(
+        db,
+        "send-welcome-email",
+        data={
+            "email": "someone@example.com",
+            "name": "Someone Like a User",
+            "stuff": "more of it"},
+    )
+```
+
+The utility of using `put` within a transaction is that often tasks that are meant to
+be processed asynchronously should only be enqueued if the generating process succeeds.
+The above relies on the database transaction successfully being committed as a strong
+indicator that the user was successfully created and therefore should receive a welcome
+email. However, there is no requirement that `put` must be called within a transaction.
+
+Processing tasks entails creating and running a worker process.
+
+```Python
+from asyncpg_queue import Worker
+
+
+def send_welcome_email(email, name, **kwargs):
+    print("sending a welcome email!")
+
+
+worker = Worker(
+    "postgresqlL//postgres@127.0.0.1:5432/postgres",
+    tasks={
+        "send-welcome-email": send_welcome_email,
+    }
+)
+await worker.run()
+```
+
+Notice the `tasks` parameter passed as part of `Worker`'s initialization. This map
+instructs the worker to process the "send-welcome-email" queue of tasks with the
+specified function.
+
+## Contributing
+
+asyncpg-queue uses [Poetry](https://github.com/python-poetry/poetry) to manage its
+dependencies, development tooling, and buiild.
+
+```sh
+poetry install
+```
+
+### Testing
+
+A Docker container running Postgres is used during testing. Assuming that `docker` is
+available on your system path at the time of running tests, the appropriate image(s)
+will be pulled.
+
+Tests are invoked by Pytest:
+
+```sh
+poetry run pytest test/
+```
+
+Alternatively, if you have a running Postgres instance and do not want to rely on
+Docker, pass the DSN of a running Postgres instance that can be used during testing:
+
+```sh
+poetry run pytest  --postgres-dsn=postgresql://postgres@localhost:5433/postgres test/
+```
+
+### Formatting
+
+Code formatting is enforced by [Black](https://github.com/psf/black):
+
+```sh
+poetry run black .
+```
+
+### Static analysis
+
+Linting (and auto-fixing where possible) is done by [Ruff](https://github.com/charliermarsh/ruff/):
+    
+```sh
+poetry run ruff check --fix .
+```
+    
+Types are checked with [Mypy](https://github.com/python/mypy):
+
+```sh
+poetry run mypy --install-types ./asyncpg_queue/ ./test/
+```
+
+Unused code is checked by [Vulture](https://github.com/jendrikseipp/vulture):
+
+```sh
+poetry run vulture asyncpg_queue/ test/
+```
+
+## Motivation
+
+Keep your project simple as long as possible! While simplicity is in the eye of the
+beholder, the definition used here amounts to, refrain from adding additional tools
+until necessary.
+
+Many projects begin simply with a server and a data-store. Eventually, as the project
+gains users and gathers complexity there may be a need for doing _something_ in a
+separate process so as to not impede the main line. This something could be sending
+emails by poking some email SaaS provider's API or calculating the total number of new
+users of a particular feature at the end of the day. asyncpg-queue is meant for this
+moment in an application's history.
+
+asyncpg-queue and similar implementations have been successfully used to prolong or
+forestall implementing queues and background workers with Redis, Celery or a variety
+of other data stores. While many of these tools are not difficult to operate and PaaS
+vendors often have a managed version, there is always an additional complexity cost
+from introducing a new tool. asyncpg-queue should keep your toolset consistent since
+it only relies on Python and Postgres.
+
+## When _not_ to use
+
+The primary caveat of this library is that if the database is the bottleneck in an
+application deployment then using this tool will only add to the pressure on Postgres.
+There will be more connections opened, more queries, and some additional data stored.
+If any of those areas are problems, they will almost undoubtedly get worse with the
+introduction of asyncpg-queue.
+
+While fast enough, asyncpg-queue has little ability to ramp the performance of
+producers (ie: adding to the queue) or consumers (ie: popping from the queue) because
+of its reliance on Postgres. Only so much data can be written or read given a network
+configuration and the server instance running Postgres. To play around with this idea
+consult [`example/benchmark/producer.py`](example/benchmark/producer.py) and
+[`example/benchmark/consumer.py`](example/benchmark/consumer.py) which should provide
+estimates of the maximum read and write throughput of your setup.
+
+asyncpg-queue is well suited for workloads that are mostly I/O. An example would be
+calculating an end-of-day rollup table in Postgres that takes a long time to run.
+However, asyncpg-queue is ill suited for running many CPU intensive tasks, like
+training a neural network or performing the same end-of-day rollup in memory. In these
+cases it's necessary to pay attention to the `concurrency` parameter of `Worker`.

--- a/asyncpg_queue/__init__.py
+++ b/asyncpg_queue/__init__.py
@@ -1,0 +1,15 @@
+"""asyncpg-queue, background workers using Postgres and asyncpg."""
+
+import logging
+
+from . import queue
+from .bootstrap import bootstrap
+from .worker import Worker
+
+__all__ = (
+    "bootstrap",
+    "queue",
+    "Worker",
+)
+
+handler = logging.NullHandler()

--- a/asyncpg_queue/bootstrap.py
+++ b/asyncpg_queue/bootstrap.py
@@ -1,0 +1,68 @@
+from logging import getLogger
+from pathlib import Path
+
+import asyncpg
+from asyncpg.exceptions import SyntaxOrAccessError
+
+log = getLogger(__name__)
+
+
+class VersionDoesNotExistException(ValueError):  # noqa: D101
+    def __init__(self, *args: object) -> None:  # noqa: D107
+        super().__init__(*args)
+
+
+async def _bootstrap(
+    connection: asyncpg.Connection,
+    *,
+    version_target: str,
+) -> None:
+    try:
+        current_version = await connection.fetchval(
+            "SELECT version FROM _asyncpg_queue_schema_version WHERE latest"
+        )
+    except SyntaxOrAccessError:
+        current_version = None
+
+    if current_version == version_target.strip(".sql"):
+        log.info(
+            "asyncpg-queue's database schema is up to date and does not require "
+            "upgrading or bootstrap"
+        )
+        return
+    versions_dir = Path(__file__).parent / "version"
+    target = versions_dir / version_target
+    if not target.exists():
+        raise VersionDoesNotExistException(
+            f"{target} does not exist, check the file path"
+        )
+    schema = target.read_text()
+    async with connection.transaction():
+        await connection.execute(schema)
+
+
+async def bootstrap(
+    db: asyncpg.Connection | str, *, version_target: str = "20230111.sql"
+) -> None:
+    """
+    Create the Postgres objects that asyncpg-queue relies upon.
+
+    Bootstrapping asyncpg-queue is a simple database migration that is executed within
+    a transaction. Future version upgrades will rely on previous versions having been
+    previously applied. If previous versions have not been applied, bootstrapping will
+    apply them.
+
+    :param db:
+        Specifies a :class:`asyncpg.Connection` object or Postgres DSN to use for
+        bootstrapping the database.
+    :param version_target:
+        Specifies the SQL file from the `version` directory to run.
+    """
+    if isinstance(db, asyncpg.Connection):
+        await _bootstrap(db, version_target=version_target)
+    else:
+        try:
+            connection = await asyncpg.connect(db)
+            await _bootstrap(connection, version_target=version_target)
+        finally:
+            await connection.close()

--- a/asyncpg_queue/queue.py
+++ b/asyncpg_queue/queue.py
@@ -1,0 +1,109 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Iterable
+from uuid import UUID
+
+import asyncpg
+
+
+@dataclass(kw_only=True)
+class Task:
+    """
+    Container for task data.
+
+    :param id:
+        The primary key identifier of the task stored in Postgres.
+    :param name:
+        The queue that the task is part of. Used to determine the processing
+        function.
+    :param enqueued:
+        Time at which the task was written to Postgres.
+    :param dequeued:
+        Time at which the task was popped from Postgres to begin processing.
+    :param data:
+        Input(s) to the processing function.
+    """
+
+    id: UUID
+    name: str
+    enqueued: datetime
+    dequeued: datetime | None = None
+    data: Any = ...
+
+
+async def put(
+    db: asyncpg.Connection, queue: str | Callable[..., Any], data: Any
+) -> Task:
+    """
+    Add a test to the queue.
+
+    This method should be used within a Postgres transaction otherwise it will
+    may enqueue work that should not be upon some other process upon which the
+    queued work depends failing.
+
+    :param db:
+        A database connection, ideally with a previously opened transaction.
+
+    :param queue:
+        The name of the queue to add this task to. This name will later be used
+        by a :class:`asyncpg_queue.worker.Worker` instance to map functions that
+        will perform the work to tasks.
+
+    :param data:
+        A JSON serializable object or `None` that will be stored in Postgres and
+        passed as input to the processing function.
+    """
+    task = await db.fetchrow(
+        """
+        INSERT INTO queue (name, data)
+        VALUES ($1, $2)
+        RETURNING id, name, enqueued, data
+        """,
+        queue if isinstance(queue, str) else queue.__qualname__,
+        json.dumps(data),
+    )
+    return Task(**task)
+
+
+async def pop(db: asyncpg.Connection, queues: Iterable[str]) -> Task | None:
+    """
+    Remove a task from the queue.
+
+    This method should likely be used within a Postgres transaction otherwise it will
+    instantly mark the given task as dequeued. While not particularly a problem, it may
+    be unexpected.
+
+    Tasks are popped in the order in which they were enqueud, filitered by the
+    specified queues. Tasks that are currently locked for processing will not be
+    popped until their lock is released.
+
+    :param db:
+        A database connection, ideally with a previously opened transaction.
+
+    :param queues:
+        Which queues should be considered for getting the next task for processing.
+    """
+    task = await db.fetchrow(
+        """
+        WITH task AS (
+            SELECT id
+            FROM queue
+            WHERE dequeued IS NULL
+                AND name = ANY($1)
+            ORDER BY enqueued
+            FOR UPDATE
+            SKIP LOCKED
+            LIMIT 1
+        )
+        UPDATE queue
+        SET dequeued = NOW()
+        FROM task
+        WHERE queue.id = task.id
+        RETURNING queue.id, queue.name, queue.enqueued, queue.dequeued, queue.data
+        """,
+        queues,
+    )
+    if not task:
+        return None
+    return Task(**task)

--- a/asyncpg_queue/version/20230111.sql
+++ b/asyncpg_queue/version/20230111.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS _asyncpg_queue_schema_version (
+    date_applied TIMESTAMP DEFAULT NOW(),
+    latest BOOL NOT NULL,
+    version TEXT NOT NULL
+);
+
+COMMENT ON TABLE _asyncpg_queue_schema_version IS 'Database versions that have been applied for asyncpg-queue';
+COMMENT ON COLUMN _asyncpg_queue_schema_version.date_applied IS 'Date at which the version was applied';
+COMMENT ON COLUMN _asyncpg_queue_schema_version.latest IS 'Indicator of the most recent version';
+COMMENT ON COLUMN _asyncpg_queue_schema_version.version IS 'Name of the version';
+
+INSERT INTO _asyncpg_queue_schema_version (version, latest) VALUES ('20230111', True);
+
+CREATE TABLE IF NOT EXISTS queue (
+    id UUID PRIMARY KEY DEFAULT GEN_RANDOM_UUID(),
+    enqueued TIMESTAMP DEFAULT NOW(),
+    dequeued TIMESTAMP,
+    name TEXT,
+    data JSONB
+);
+
+COMMENT ON TABLE queue IS 'Collection of tasks to process asynchronously';
+COMMENT ON COLUMN queue.enqueued IS 'Time task was enqueued';
+COMMENT ON COLUMN queue.dequeued IS 'Time task was popped from queue to begin processing';
+COMMENT ON COLUMN queue.name IS 'The task to be perfomed';
+COMMENT ON COLUMN queue.data IS 'Deserializable data to be passed to the process performing the queued task';
+
+CREATE INDEX IF NOT EXISTS queue_enqueued_idx ON queue (enqueued) WHERE dequeued IS NULL;
+CREATE INDEX IF NOT EXISTS queue_dequeued_idx ON queue (dequeued) WHERE dequeued IS NULL;
+CREATE INDEX IF NOT EXISTS queue_name_idx ON queue (name) WHERE dequeued IS NULL;
+
+CREATE OR REPLACE FUNCTION _asyncpg_queue_notify() RETURNS TRIGGER AS $$ BEGIN
+    PERFORM pg_notify('asyncpg_queue_task'::TEXT, '');
+    RETURN NULL;
+END $$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION _asyncpg_queue_notify IS 'Notify channel used by asyncpg-queue';
+
+CREATE OR REPLACE TRIGGER _asyncpg_queue_insert
+AFTER INSERT ON queue
+FOR EACH ROW
+EXECUTE PROCEDURE _asyncpg_queue_notify();
+
+COMMENT ON TRIGGER _asyncpg_queue_insert ON queue IS 'When a new task is inserted into the queue table notify the channel used by asyncpg-queue';

--- a/asyncpg_queue/worker.py
+++ b/asyncpg_queue/worker.py
@@ -1,0 +1,334 @@
+import asyncio
+import contextvars
+import functools
+import json
+import os
+import signal
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from logging import getLogger
+from threading import current_thread
+from typing import Any, Callable, Mapping, Self
+
+import asyncpg
+
+from asyncpg_queue.queue import pop
+
+log = getLogger(__name__)
+
+
+class Worker:
+    """
+    Create a worker that processes the specified task queues stored in Postgres.
+
+    :param dsn:
+        Postgres connection string that follows the form specified by
+        https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING.
+    :param tasks:
+        Container of tasks specifying a mapping of callables to queues for processing
+        by the worker instance.
+    :param burst:
+        Upon the worker exhausting the specified queues, shut the worker down after
+        all task executions have been completed or failed.
+    :param concurrency:
+        The maximum number of concurrent tasks that can be processed at once. This
+        number is synonomous with the number of database connections plus one that will
+        be instantiated _and_ the number of threads that will be used to create a
+        :class:`concurrent.futures.ThreadPoolExecutor` for processing synchronous
+        tasks. This number has one added to it to account for a background housekeeping
+        task that is used for handling Postgres notifications among other activities.
+    :param timeout:
+        Default timeout in seconds for each task instance. Task instances that exceed
+        this threshold will be cancelled by a :exc:`TimeoutError`. To disable default
+        task timeouts use `None`.
+    """
+
+    __slots__ = (
+        "burst",
+        "concurrency",
+        "default_timeout",
+        "tasks",
+        "_awake",
+        "_dsn",
+        "_housekeeping_seconds",
+        "_loop",
+        "_running_tasks",
+        "_shutdown_event",
+        "_wait_for_seconds",
+        "_worker_tasks",
+    )
+
+    _worker_tasks: set[asyncio.Future[Any]]
+
+    def __init__(
+        self: Self,
+        dsn: str,
+        *,
+        tasks: Mapping[str, Callable[..., Any]],
+        burst: bool = False,
+        concurrency: int = 9,
+        timeout: timedelta | float | int | None = timedelta(minutes=1),  # noqa: B008
+        _housekeeping_seconds: float | int = 300
+    ) -> None:
+        """Initialize a worker instance."""
+        self.burst = burst
+        self.concurrency = concurrency
+        if not isinstance(timeout, timedelta):
+            self.default_timeout = timeout or float("inf")
+        else:
+            self.default_timeout = timeout.total_seconds()
+        self.tasks = tasks
+        self._awake = asyncio.Lock()
+        self._dsn = dsn
+        self._housekeeping_seconds = _housekeeping_seconds
+        self._loop = asyncio.get_event_loop()
+        self._shutdown_event = asyncio.Event()
+        self._wait_for_seconds = float(min(0.5, self.default_timeout))
+        self._worker_tasks = set()
+
+    async def run(self: Self) -> None:
+        """Run the worker."""
+        self._install_signal_handlers()
+        pid = os.getpid()
+        log.info("Running worker (%s)", pid)
+        async with asyncpg.create_pool(
+            self._dsn, max_size=self.concurrency + 1, min_size=2
+        ) as pool:
+            with ThreadPoolExecutor(
+                max_workers=min(32, os.cpu_count() or 1 + 4, self.concurrency),
+                thread_name_prefix="asyncpg-queue",
+                initializer=self._thread_initializer,
+            ) as executor:
+                log.debug("Worker beginning processing tasks")
+
+                housekeeping_task = asyncio.create_task(
+                    self._housekeeping(pool), name="asyncpg-queue-housekeeping"
+                )
+                self._worker_tasks.add(housekeeping_task)
+                housekeeping_task.add_done_callback(self._task_done_callback)
+
+                while not self._shutdown_event.is_set():
+                    try:
+                        if len(self._worker_tasks) >= self.concurrency:
+                            done, pending = await asyncio.wait(
+                                self._worker_tasks,
+                                timeout=self._wait_for_seconds,
+                                return_when=asyncio.ALL_COMPLETED,
+                            )
+                            log.debug(
+                                "Concurrency threshold of %s reached, waiting for %ss, "
+                                "%s tasks completed, %s tasks pending",
+                                self.concurrency,
+                                self._wait_for_seconds,
+                                len(done),
+                                len(pending),
+                            )
+                            continue
+                        if not self.awake():
+                            log.debug("Worker is locked, waiting for tasks to appear")
+                            if self.burst:
+                                self.shutdown()
+                                log.info(
+                                    "Shutting down burst worker, queue exhausted",
+                                )
+                                break
+                            await asyncio.sleep(1)
+                        else:
+                            task = asyncio.create_task(self._run(pool, executor))
+                            self._worker_tasks.add(task)
+                            task.add_done_callback(self._task_done_callback)
+                            log.debug("Created worker task %s", task.get_name())
+                    except asyncio.CancelledError:
+                        self.shutdown()
+                        break
+
+                log.debug("Waiting on outstanding worker tasks to finish")
+
+                await asyncio.gather(
+                    *self._worker_tasks, housekeeping_task, return_exceptions=True
+                )
+            log.debug("Thread pool executor closed")
+        log.debug("Database connection pool closed")
+        log.info("Worker run finished (%s)", pid)
+
+    async def _run(
+        self: Self,
+        pool: asyncpg.Pool,
+        executor: ThreadPoolExecutor,
+    ) -> None:
+        async with pool.acquire() as connection:
+            async with connection.transaction():
+                task = await pop(connection, self.tasks.keys())
+                if not task:
+                    if not self.awake():
+                        log.debug("Worker already paused by lock")
+                        return
+                    await self._awake.acquire()
+                    log.debug(
+                        "No tasks in queue, lock set to pause worker task creation"
+                    )
+                    return
+                log.debug("Beginning task (%s) %s", task.name, task.id)
+                dequeued = task.dequeued or datetime.utcnow()
+                function = self.tasks[task.name]
+                data = json.loads(task.data)
+                if asyncio.iscoroutinefunction(function):
+                    if data is None:
+                        coro = function()
+                    elif isinstance(data, list):
+                        coro = function(*data)
+                    elif isinstance(data, dict):
+                        coro = function(**data)
+                    else:
+                        coro = function(data)
+                else:
+                    ctx = contextvars.copy_context()
+                    if data is None:
+                        coro = self._loop.run_in_executor(
+                            executor,
+                            functools.partial(ctx.run, function),
+                        )
+                    elif isinstance(data, list):
+                        coro = self._loop.run_in_executor(
+                            executor,
+                            functools.partial(ctx.run, function, *data),
+                        )
+                    elif isinstance(data, dict):
+                        coro = self._loop.run_in_executor(
+                            executor,
+                            functools.partial(ctx.run, function, **data),
+                        )
+                    else:
+                        coro = self._loop.run_in_executor(
+                            executor,
+                            functools.partial(ctx.run, function, data),
+                        )
+                try:
+                    result = await asyncio.wait_for(coro, timeout=self.default_timeout)
+                    log.debug(
+                        "Got result %s from job %s after %.3gs",
+                        result,
+                        task.id,
+                        (datetime.utcnow() - dequeued).total_seconds(),
+                    )
+                except TimeoutError:
+                    log.error(
+                        "Task (%s) %s timed out (%ss)",
+                        task.name,
+                        task.id,
+                        self.default_timeout,
+                    )
+                except Exception:
+                    log.exception(
+                        "Task (%s) %s failed (%ss)",
+                        task.name,
+                        task.id,
+                        self.default_timeout,
+                    )
+                await connection.execute(
+                    "DELETE FROM queue WHERE id = $1",
+                    task.id,
+                )
+
+    def awake(self) -> bool:
+        """
+        Is the worker currently processing tasks?.
+
+        An awake worker is one that is querying Postgres for enqueued tasks to pop
+        from the queue and then attempt to process.
+        """
+        return not self._awake.locked()
+
+    async def _wake(
+        self: Self,
+        conn: asyncpg.Connection,
+        pid: int,
+        channel: str,
+        payload: Any,
+    ) -> None:
+        del conn
+        if self.awake():
+            return  # pragma: no cover
+        self._awake.release()
+        log.debug(
+            "Received notification from Postgres channel to release lock and wake "
+            "worker",
+            extra={"pid": pid, "channel": channel, "payload": payload},
+        )
+
+    def shutdown(self) -> None:
+        """
+        Shutdown the worker and associated tasks.
+
+        Cancels all outstanding worker tasks, usually invoked when handling signals.
+        """
+        log.debug("Beginning shutdown")
+        self._shutdown_event.set()
+        for task in self._worker_tasks:
+            if not task.done():  # pragma: no cover
+                task.cancel()
+        log.debug("All worker tasks cancelled")
+
+    async def _housekeeping(
+        self: Self,
+        pool: asyncpg.Pool,
+    ) -> None:
+        """
+        Perform housekeeping tasks to keep the worker instance happy.
+
+        Housekeeping is currently a single action: Open a long-lived Postgres
+        connection to receive any notifications on the appropriate channel that are
+        used to wake the worker so that it can begin processing tasks.
+        """
+        if self._shutdown_event.is_set():
+            return  # pragma: no cover
+        if pool._closed:
+            return  # pragma: no cover
+        try:
+            async with pool.acquire() as connection:  # pragma: no cover
+                try:
+                    await connection.add_listener("asyncpg_queue_task", self._wake)
+                    try:
+                        await asyncio.sleep(self._housekeeping_seconds)
+                    except asyncio.CancelledError:
+                        return
+                finally:
+                    # Remove the listener before returning the connectionn to the
+                    # pool to prevent asyncpg from raising a warning.
+                    await connection.remove_listener(
+                        "asyncpg_queue_task",
+                        self._wake,
+                    )
+        except (
+            asyncpg.InterfaceError,
+            asyncpg.ConnectionDoesNotExistError,
+        ):  # pragma: no cover
+            # This can happen if the pool has been closed already. Handling the error
+            # by ignoring it prevents some scary looking errors from propagating up.
+            return
+        except asyncio.CancelledError:
+            return
+
+        housekeeping_task = asyncio.create_task(
+            self._housekeeping(pool), name="asyncpg-queue-housekeeping"
+        )
+        log.debug("Recreated Housekeeping")
+        self._worker_tasks.add(housekeeping_task)
+        housekeeping_task.add_done_callback(self._task_done_callback)
+        log.debug("Finished housekeeping task")
+
+    def _thread_initializer(self) -> None:
+        log.debug(
+            "Initializing worker thread", extra={"thread_name": current_thread().name}
+        )
+
+    def _task_done_callback(self: Self, t: asyncio.Future[Any]) -> None:
+        self._worker_tasks.remove(t)
+        try:
+            t.exception()
+        except asyncio.CancelledError:
+            log.exception("Task cancelled during processing")
+
+    def _install_signal_handlers(self: Self) -> None:
+        self._loop.add_signal_handler(signal.SIGHUP, self.shutdown)
+        self._loop.add_signal_handler(signal.SIGTERM, self.shutdown)

--- a/example/benchmark/README.md
+++ b/example/benchmark/README.md
@@ -1,0 +1,26 @@
+# Performance benchmark
+
+The performance benchmark is meant to, for a given network and server setup, provide
+an estimate of the maximum put and pop throughout that's possible. Remember, these
+values will not be particularly high because of the reliance on Postgres, but they are
+likely high enough for many simpler use cases.
+
+Start a Docker container for the queue:
+
+    docker run \
+      --rm
+      --name asyncpg-queue-benchmark \
+      -d \
+      -p 5433 \
+      -e POSTGRES_HOST_AUTH_METHOD=trust
+      postgres:15-alpine
+
+Run the producer script to get an estimate of enqueuing throughput:
+
+    python example/benchmark/producer.py 1000  # tasks to enqueue
+    # Enqueued 1000 tasks in 1.488s (0.0015s/task)
+
+Run the consumer script to get an estimate of dequeuing and processing a no-op task:
+
+    python example/benchmark/consumer.py 10  # number of concurrent coroutines
+    # Processed 1000 tasks in 56.29s (0.056s/task)

--- a/example/benchmark/consumer.py
+++ b/example/benchmark/consumer.py
@@ -1,0 +1,44 @@
+import asyncio
+import logging
+import sys
+import time
+from datetime import timedelta
+
+from asyncpg_queue import bootstrap, Worker
+
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s %(name)s %(levelname)s %(message)s"
+)
+logging.captureWarnings(True)
+
+
+async def main(concurrency: int) -> None:
+    counter = 0
+
+    async def f() -> None:
+        nonlocal counter
+        counter += 1
+
+    db = "postgresql://postgres@0.0.0.0:5433/postgres"
+
+    await bootstrap(db)
+
+    worker = Worker(
+        db,
+        tasks={"f": f},
+        burst=True,
+        concurrency=concurrency,
+    )
+    start = time.monotonic()
+    await worker.run()
+    end = time.monotonic()
+    time_spent = end - start
+    try:
+        rate = time_spent / counter
+    except ZeroDivisionError:
+        rate = 0
+    print(f"Processed {counter} tasks in {time_spent:.4}s ({rate:.2}s/task)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(int(sys.argv[1])))

--- a/example/benchmark/producer.py
+++ b/example/benchmark/producer.py
@@ -1,0 +1,32 @@
+import asyncio
+import random
+import sys
+import time
+from datetime import timedelta
+
+import asyncpg
+import uvloop
+
+from asyncpg_queue import bootstrap, queue
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+
+async def f() -> None:
+    pass
+
+
+async def main(i: int) -> None:
+    db = "postgresql://postgres@0.0.0.0:5433/postgres"
+    await bootstrap(db)
+    connection = await asyncpg.connect(db)
+    start = time.monotonic()
+    for _ in range(i):
+        await queue.put(connection, f, None)
+    end = time.monotonic()
+    time_spent = end - start
+    print(f"Enqueued {i} tasks in {time_spent:.4}s ({(time_spent / i):.2}s/task)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(int(sys.argv[1])))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,142 @@
+[tool.poetry]
+name = "asyncpg-queue"
+version = "0.1.0"
+description = ""
+authors = ["nate giraldi <ng269@cornell.edu>"]
+readme = "README.md"
+packages = [
+  {include = "asyncpg_queue"},
+  {include = "asyncpg_queue/py.typed"},
+]
+license = "MIT"
+classifiers = [
+  "Development Status :: 4 - Beta",
+	"Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<3.12"
+asyncpg = "<0.28,>=0.26"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.1.0"
+mypy = "^1.0.1"
+ruff = "*"
+vulture = "^2.7"
+
+[tool.poetry.group.test.dependencies]
+docker = "^6.0.1"
+nox = "^2022.11.21"
+pytest = "^7.2.0"
+pytest-asyncio = "^0.20.3"
+pytest-cov = "^4.0.0"
+pytest-mock = "^3.10.0"
+pytest-randomly = "^3.12.0"
+pytest-timeout = "^2.1.0"
+
+[tool.black]
+include = '\.pyi?$'
+
+[tool.coverage.paths]
+source = ["asyncpg_queue"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "if typing.TYPE_CHECKING:",
+  "if __name__ == \"__main__\":",
+  "if settings().debug",
+  "log.*"
+]
+fail_under = 100
+show_missing = true
+skip_empty = true
+
+[tool.coverage.run]
+branch = true
+source = ["asyncpg_queue"]
+
+[tool.mypy]
+strict = true
+enable_error_code = ["ignore-without-code"]
+enable_incomplete_feature = ["Unpack"]
+
+[[tool.mypy.overrides]]
+module = [
+  "asyncpg.*",
+  "docker.*",
+]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+norecursedirs = [
+  ".venv",
+  "dist",
+  "build",
+  "docs",
+  ".git",
+  "__pycache__",
+]
+addopts = [
+  "-r fEsx",
+  "--failed-first",
+  "--new-first",
+  "--strict-config",
+  "--strict-markers",
+  "--tb=short",
+  "--doctest-modules",
+  "--cov",
+  "--cov-config=pyproject.toml",
+  "--asyncio-mode=auto",
+  "--show-capture=no",
+]
+filterwarnings = [
+  "ignore:.*is being released to the pool but has 1 active notification listener:asyncpg.InterfaceWarning",
+]
+# pytest-timeout is a steamroller, but a useful one when running complicated and
+# potentially hacky async tests like this library currently relies on. Sometimes these
+# tests, if written incorrectly which may or may not have happened during development,
+# may find themselves in a hung state, which the timeout will unceremoniously
+# steamroll.
+timeout = 30
+
+[tool.ruff]
+external = [
+  "V101"  # Vulture is not supported by Ruff
+]
+fix = true
+select = [
+  "F",  # Pyflakes
+  "E", "W",  # pycodestyle
+  "W",
+  "C",  # mccabe
+  "I",  # isort
+  "S",  # flake8-bandit
+  "B",  # flake8-bugbear
+  "D",  # pydocstyle
+]
+ignore = [
+  "D100",  # docstring in public module
+  "D203",  # conflicts with D211
+  "D212",  # conflicts with D212
+]
+
+[tool.ruff.isort]
+lines-after-imports = -1
+
+[tool.ruff.per-file-ignores]
+"example/*" = ["D"]
+"test/*" = ["S101", "D"]
+
+[tool.vulture]
+min_confidence = 100
+paths= ["asyncpg_queue", "test"]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,106 @@
+import asyncio
+import contextlib
+import socket
+import time
+from typing import Generator
+from uuid import uuid4
+
+import asyncpg
+import docker
+import pytest
+
+from asyncpg_queue.bootstrap import bootstrap
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--postgres-version",
+        action="store",
+        default="15",
+        help="Major version of Postgres to use.",
+    )
+    parser.addoption(
+        "--postgres-dsn",
+        action="store",
+        default=None,
+        help=(
+            "Connection string for already existing Postgres. Useful when running in "
+            "CI or another environment where a Postgres instance is already running "
+            "and available for using during test."
+        ),
+    )
+
+
+@pytest.fixture
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+def postgres_version(request):  # type: ignore[no-untyped-def]
+    return request.config.getoption("--postgres-version")
+
+
+@pytest.fixture(scope="session")
+def postgres_dsn(request):  # type: ignore[no-untyped-def]
+    return request.config.getoption("--postgres-dsn")
+
+
+@pytest.fixture(scope="session")
+def docker_client() -> docker.DockerClient:
+    return docker.from_env()
+
+
+@pytest.fixture(scope="session")
+def open_port() -> int:
+    with contextlib.closing(socket.socket(type=socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]  # type: ignore[no-any-return]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def postgres(
+    docker_client: docker.DockerClient,
+    open_port: int,
+    postgres_dsn: str | None,
+    postgres_version: str,
+) -> Generator[str, None, None]:
+    if not postgres_dsn:
+        container = docker_client.containers.run(
+            f"postgres:{postgres_version}-alpine",
+            detach=True,
+            name=f"asyncpg-queue-test-{uuid4().hex}",
+            environment={"POSTGRES_HOST_AUTH_METHOD": "trust"},
+            ports={
+                "5432/tcp": open_port,
+            },
+            remove=True,
+        )
+        postgres_dsn = f"postgresql://postgres@0.0.0.0:{open_port}/postgres"
+    while True:
+        time.sleep(0.1)
+        try:
+            asyncio.run(bootstrap(postgres_dsn))
+            break
+        except Exception:  # noqa: S112
+            continue
+    try:
+        yield postgres_dsn
+    finally:
+        try:
+            container.stop()
+        # NameError will be thrown if the container wasn't created for some reason
+        # so don't try to stop a container that hasn't been created ie: doesn'that
+        # exist.
+        except NameError:
+            pass
+
+
+@pytest.fixture
+async def db(postgres: str) -> asyncpg.Connection:
+    return await asyncpg.connect(postgres)

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -1,0 +1,34 @@
+import asyncpg
+import pytest
+
+from asyncpg_queue.queue import Task, pop, put
+
+
+@pytest.fixture(scope="function")
+async def task(db: asyncpg.Connection) -> Task:
+    return await put(db, "func", {"x": 1, "y": "qwerty", "z": True})
+
+
+@pytest.mark.asyncio
+async def test_put(task: Task) -> None:
+    assert task
+
+
+async def test_put_callable(db: asyncpg.Connection) -> None:
+    def tasky() -> None:
+        pass
+
+    task = await put(db, tasky, None)
+    assert task.name == "test_put_callable.<locals>.tasky"
+
+
+@pytest.mark.asyncio
+async def test_pop(db: asyncpg.Connection, task: Task) -> None:
+    popped_task = await pop(db, ("func",))
+    assert popped_task
+
+
+@pytest.mark.asyncio
+async def test_pop_empty_queue(db: asyncpg.Connection) -> None:
+    popped_task = await pop(db, ("nothing to see here",))
+    assert popped_task is None

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,0 +1,30 @@
+import asyncpg
+import pytest
+
+from asyncpg_queue.bootstrap import VersionDoesNotExistException, bootstrap
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_queue_table_exists(db: asyncpg.Connection) -> None:
+    assert await db.fetchval(
+        "SELECT EXISTS(SELECT * FROM information_schema.tables WHERE table_name = 'queue')"  # noqa: E501
+    )
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_bad_version(db: asyncpg.Connection) -> None:
+    with pytest.raises(VersionDoesNotExistException):
+        await bootstrap(db, version_target="does not exist")
+
+
+async def test_bootstrap_target_already_applied(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    caplog,
+) -> None:
+    caplog.set_level("INFO")
+    await bootstrap(db)
+    log_message = (
+        "asyncpg-queue's database schema is up to date and does not require "
+        "upgrading or bootstrap"
+    )
+    assert log_message in caplog.text

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -1,0 +1,341 @@
+import asyncio
+import json
+import time
+from typing import Any, Callable, Mapping
+from uuid import uuid4
+
+import asyncpg
+import pytest
+
+import asyncpg_queue
+from asyncpg_queue.queue import put
+from asyncpg_queue.worker import Worker
+
+
+@pytest.fixture
+def worker_run(  # type: ignore[no-untyped-def]
+    event_loop: asyncio.AbstractEventLoop,
+    postgres: str,
+):
+    worker = None
+    worker_task = None
+
+    def _worker_run(  # type: ignore[no-untyped-def]
+        tasks: Mapping[str, Callable[..., Any]],
+        burst: bool = True,
+        **kwargs,
+    ):
+        nonlocal worker
+        nonlocal worker_task
+
+        # This will implicitly test that the housekeeping task recreates itself
+        # by forcing the length of time the task holds its Postgres connection open
+        # to be very short, thereby getting to the next iteration quickly.
+        if "_housekeeping_seconds" not in kwargs:
+            kwargs["_housekeeping_seconds"] = 0.1
+
+        worker = Worker(
+            postgres,
+            tasks=tasks,
+            burst=burst,
+            **kwargs,
+        )
+        worker_task = event_loop.create_task(worker.run())
+        event_loop.run_until_complete(worker_task)
+        return worker
+
+    yield _worker_run
+
+    if worker:
+        worker.shutdown()
+
+    if worker_task and not worker_task.cancelled():
+        event_loop.run_until_complete(worker_task)
+
+
+@pytest.fixture
+def put_task(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    event_loop: asyncio.AbstractEventLoop,
+):
+    def _put(
+        func: Callable[..., Any], data: Any | None = None
+    ) -> asyncpg_queue.queue.Task:
+        task = event_loop.run_until_complete(put(db, func, data))
+        return task
+
+    yield _put
+
+
+def test_worker_async_task_input_none(  # type: ignore[no-untyped-def]
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.AsyncMock()
+    _ = put_task("f", None)
+    worker_run({"f": f}, burst=True)
+    f.assert_awaited_once()
+
+
+_single_input_data = ("x", 1, True)
+_array_input_data = (  # type: ignore[var-annotated]
+    [],
+    list(range(1000)),
+    [True, "X", (1, 2, False)],
+    tuple(range(1000)),
+)
+_map_input_data = (  # type: ignore[var-annotated]
+    {},
+    {"X": "x", 1: list(range(999))},
+    {"Y": {"Z": [1, 2, None], "a": None}},
+)
+
+
+@pytest.mark.parametrize("data", _single_input_data)
+def test_worker_async_task_single_input(  # type: ignore[no-untyped-def]
+    data,
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.AsyncMock()
+    _ = put_task("test_worker_async_task", data)
+    worker_run({"test_worker_async_task": f}, burst=True)
+    f.assert_awaited_once_with(data)
+
+
+async def test_worker_default_timeout_int(postgres: str) -> None:
+    w = Worker(postgres, tasks={}, timeout=1)
+    assert float("inf") > w.default_timeout > 0
+
+
+@pytest.mark.parametrize("data", _array_input_data)
+def test_worker_async_task_input_list(  # type: ignore[no-untyped-def]
+    data: list[Any],
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.AsyncMock()
+    _ = put_task("test_worker_async_task", data)
+    worker_run({"test_worker_async_task": f})
+    f.assert_awaited_once_with(*json.loads(json.dumps(data)))
+
+
+@pytest.mark.parametrize("data", _map_input_data)
+def test_worker_async_task_input_map(  # type: ignore[no-untyped-def]
+    data: dict[Any, Any],
+    db: asyncpg.Connection,
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.AsyncMock()
+    _ = put_task("test_worker_async_task", data)
+    worker_run({"test_worker_async_task": f})
+    f.assert_called_once_with(**json.loads(json.dumps(data)))
+
+
+def test_worker_sync_task_none_input(  # type: ignore[no-untyped-def]
+    mocker, put_task, worker_run
+) -> None:
+    f = mocker.MagicMock()
+    _ = put_task("test_worker_async_task", None)
+    worker_run({"test_worker_async_task": f})
+    f.assert_called_once_with()
+
+
+@pytest.mark.parametrize("data", _single_input_data)
+def test_worker_sync_task_single_input(  # type: ignore[no-untyped-def]
+    data: Any, mocker, put_task, worker_run
+) -> None:
+    f = mocker.MagicMock()
+    _ = put_task("f", data)
+    worker_run({"f": f})
+    f.assert_called_once_with(data)
+
+
+@pytest.mark.parametrize("data", _array_input_data)
+def test_worker_sync_task_list_input(  # type: ignore[no-untyped-def]
+    data: list[Any],
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.MagicMock()
+    _ = put_task("f", data)
+    worker_run({"f": f})
+    f.assert_called_once_with(*json.loads(json.dumps(data)))
+
+
+@pytest.mark.parametrize("data", _map_input_data)
+def test_worker_sync_task_map_input(  # type: ignore[no-untyped-def]
+    data: dict[Any, Any],
+    db: asyncpg.Connection,
+    mocker,
+    put_task,
+    worker_run,
+) -> None:
+    f = mocker.MagicMock()
+    _ = put_task("test_worker_async_task", data)
+    worker_run({"test_worker_async_task": f})
+    f.assert_called_once_with(**json.loads(json.dumps(data)))
+
+
+def test_worker_async_task_throws_exception(  # type:ignore[no-untyped-def]
+    caplog,
+    db: asyncpg.Connection,
+    put_task,
+    worker_run,
+) -> None:
+    async def f() -> None:
+        raise Exception()
+
+    caplog.set_level("ERROR")
+    _ = put_task("test_worker_task_throws_exception")
+    worker_run({"test_worker_task_throws_exception": f})
+    assert "failed" in caplog.text
+
+
+async def test_worker_sleeps(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    event_loop,
+    mocker,
+    postgres: str,
+) -> None:
+    f = mocker.MagicMock()
+    await put(db, "test_worker_sleeps", None)
+    worker = Worker(postgres, tasks={"test_worker_sleeps": f}, burst=False)
+    worker_task = event_loop.create_task(worker.run())
+    while not worker._awake.locked():
+        await asyncio.sleep(0.01)
+        continue
+    assert worker._awake.locked()
+    worker.shutdown()
+    await asyncio.gather(worker_task)
+
+
+async def test_worker_wakes_from_sleep(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection, postgres: str, event_loop: asyncio.AbstractEventLoop, mocker
+) -> None:
+    f = mocker.MagicMock()
+    worker = Worker(postgres, tasks={"test_worker_sleeps": f}, burst=False)
+    worker_task = event_loop.create_task(worker.run())
+    while not worker._awake.locked():
+        await asyncio.sleep(0.01)
+    await put(db, "test_worker_sleeps", None)
+    while not f.call_count:
+        await asyncio.sleep(0.01)
+        continue
+    assert f.called_once_with()
+    worker.shutdown()
+    await asyncio.gather(worker_task)
+
+
+async def test_multiple_workers_single_call(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    event_loop: asyncio.AbstractEventLoop,
+    postgres: str,
+    mocker,
+    tmp_path,
+) -> None:
+    def f() -> None:
+        p = tmp_path / uuid4().hex
+        p.touch()
+        print(p)
+
+    worker1 = Worker(
+        postgres,
+        tasks={"test_multiple_workers_single_call": f},
+        concurrency=2,
+        burst=False,
+    )
+    worker2 = Worker(
+        postgres,
+        tasks={"test_multiple_workers_single_call": f},
+        concurrency=2,
+        burst=False,
+    )
+    await put(db, "test_multiple_workers_single_call", None)
+    worker_task1 = event_loop.create_task(worker1.run())
+    worker_task2 = event_loop.create_task(worker2.run())
+    while worker1.awake() and worker2.awake():
+        await asyncio.sleep(0.1)
+        continue
+    assert len(list(tmp_path.iterdir())) == 1
+    worker1.shutdown()
+    worker2.shutdown()
+    await asyncio.gather(worker_task2, worker_task1)
+
+
+async def test_worker_cancellation_task_resume(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    postgres: str,
+    event_loop: asyncio.AbstractEventLoop,
+    mocker,
+) -> None:
+    started = False
+    finished = False
+
+    def f(t: int) -> None:
+        nonlocal started
+        nonlocal finished
+        started = True
+
+        time.sleep(t)
+        finished = True
+
+    spy = mocker.spy(f, "__call__")
+    worker1 = Worker(
+        postgres, tasks={"test_worker_cancellation_task_resume": spy}, burst=False
+    )
+    worker2 = Worker(
+        postgres, tasks={"test_worker_cancellation_task_resume": spy}, burst=False
+    )
+    worker_task1 = event_loop.create_task(worker1.run())
+    sleep_for = 5
+    await put(db, "test_worker_cancellation_task_resume", sleep_for)
+    while not started:
+        await asyncio.sleep(0.1)
+    worker1.shutdown()
+    assert not finished
+    worker_task2 = event_loop.create_task(worker2.run())
+    while worker2.awake():
+        await asyncio.sleep(0.1)
+    assert finished
+    worker2.shutdown()
+    await asyncio.gather(worker_task1, worker_task2)
+
+
+async def test_worker_handles_cancellation_error(  # type: ignore[no-untyped-def]
+    event_loop: asyncio.AbstractEventLoop, mocker, postgres: str
+) -> None:
+    spy = mocker.spy(Worker, "shutdown")
+    worker_task = event_loop.create_task(Worker(postgres, tasks={}).run())
+    await asyncio.sleep(1)
+    worker_task.cancel()
+    await asyncio.gather(worker_task)
+    spy.assert_called_once()
+
+
+async def test_worker_shutdown(  # type: ignore[no-untyped-def]
+    db: asyncpg.Connection,
+    event_loop: asyncio.AbstractEventLoop,
+    mocker,
+    postgres: str,
+    put_task,
+) -> None:
+    async def f(t: int) -> None:
+        await asyncio.sleep(t)
+
+    concurrency = 10
+    worker = Worker(postgres, tasks={"test_worker_shutdown": f}, concurrency=10)
+    worker_task = event_loop.create_task(worker.run())
+    for _ in range(concurrency):
+        await put(db, "test_worker_shutdown", 300)
+    while len(worker._worker_tasks) < concurrency:
+        await asyncio.sleep(0.1)
+    worker.shutdown()
+    await asyncio.gather(worker_task)
+    assert len(worker._worker_tasks) == 0


### PR DESCRIPTION
Code formatting is enforced by [Black](https://github.com/psf/black):

    poetry run black .

Linting (and auto-fixing where possible) is done by [Ruff](https://github.com/charliermarsh/ruff/):

    poetry run ruff check --fix .

Types are checked using [Mypy](https://github.com/python/mypy

    poetry run mypy --install-types ./asyncpg_queue/ ./test/

Tests are run with [pytest](https://github.com/pytest-dev/pytest):

    poetry run pytest test/

Unused code is checked by [Vulture](https://github.com/jendrikseipp/vulture):

    poetry run vulture asyncpg_queue/ test/

[Nox](https://github.com/wntrblm/nox) was considered as a test automation tool for running tests against multiple versions of Postgres and [asyncpg](https://github.com/MagicStack/asyncpg) however it seemed a bit costly in its rebuilding of environments. Considering that there's a high likelihood that this functionality will be implemented using matrixed GitHub Actions
(https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) it seemed best to not include Nox as part of this initial change.

While test coverage is 100% the tests themselves are admittedly rough. There are cases where `sleep`s were expedient, but that seems brittle and if nothing else inelegant.